### PR TITLE
WIP - add proto3 optional feature

### DIFF
--- a/firebase_rules_generator/generator.cc
+++ b/firebase_rules_generator/generator.cc
@@ -213,6 +213,10 @@ bool IsLastIteration(S idx, S size) {
 
 }  // namespace
 
+uint64_t RulesGenerator::GetSupportedFeatures() const {
+  return FEATURE_PROTO3_OPTIONAL;
+}
+
 bool RulesGenerator::Generate(const protobuf::FileDescriptor *file,
                               const std::string &parameter,
                               protobuf::compiler::GeneratorContext *context,

--- a/firebase_rules_generator/generator.h
+++ b/firebase_rules_generator/generator.h
@@ -54,6 +54,7 @@ class RulesGenerator : public protobuf::compiler::CodeGenerator {
 
   bool GenerateMap(const protobuf::FieldDescriptor* map_field,
                    protobuf::io::Printer& printer, std::string* error) const;
+  uint64_t GetSupportedFeatures() const override;
 };
 
 }  // namespace experimental

--- a/integration_test.py
+++ b/integration_test.py
@@ -81,7 +81,7 @@ def run_testcase(proto_file, output):
 # Testcases should be <name>.proto as the input and <name>.rules as the output.
 testdata.sort()
 
-for i in xrange(0, len(testdata), 2):
+for i in range(0, len(testdata), 2):
   proto_file = check_proto_file(testdata[i])
   rules_out = check_rules_file(testdata[i + 1])
   run_testcase(proto_file, rules_out)

--- a/testdata/test0.proto
+++ b/testdata/test0.proto
@@ -4,5 +4,5 @@ package example;
 message Example {
   string foo = 1;
   string bar = 2;
-  string baz = 3;
+  optional string baz = 3;
 }


### PR DESCRIPTION
Goal:
- add proto3 optional features as documented in https://github.com/protocolbuffers/protobuf/blob/main/docs/implementing_proto3_presence.md#signaling-that-your-code-generator-supports-proto3-optional

Unrelated changes:
- switch xrange to range in `integration_test.py` for python3 compatibility


WIP:
- [ ] test and validate the implication of the changes
- [ ] RTFM proto3 generator
